### PR TITLE
v0 Development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,6 @@
 language: go
+
+go:
+- 1.4.3
+- 1.5.2
+- tip

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,3 @@
+The following authors constitute the dagr authors:
+
+- Noel Cower - ncower@gmail.com

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Noel R. Cower
+Copyright (c) 2015, The Dagr Authors
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.md
+++ b/README.md
@@ -1,0 +1,122 @@
+# Dagr
+
+[![Build Status](https://travis-ci.org/nilium/dagr.svg?branch=dev-v0)](https://travis-ci.org/nilium/dagr)
+
+Dagr is a simple library for tracking measurements and writing them out in an InfluxDB line-protocol-friendly format.
+
+***Note: the Dagr API is currently unstable and may change during v0 development.*** I'll try to make these breaks
+infrequent, but keep in mind that this is being developed while it's being used, so I'll inevitably discover quirks in
+the API that I just have to fix and break something in the process. When this happens, the commit should make a note of
+the break.
+
+
+## Usage
+
+As I see it, there are roughly two categories of measurements when dealing with a program: long-term stats and events.
+The next two sections attempt to elaborate on this, but they're roughly the same and just use different types and send
+models.
+
+### Stats
+
+A **long-term stat** is something like the number of requests sent to an endpoint over its lifetime. Typically, you
+don't need to record each individual request, you just need to know how many requests have come in since the last time
+a measurement was sent. So, you keep a counter:
+
+```go
+// Setup
+counter := new(dagr.Int)
+measurement := dagr.NewPoint("http_request",
+	dagr.Tags{"host": "example.local", "method": "GET", "path": "/v1/parrots/list"},
+	dagr.Fields{"count": counter},
+)
+
+// Handler of some kind
+func (h Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// Atomically increment the counter
+	counter.Add(1)
+}
+
+// Every now and then, write it to a stream that somehow gets over to InfluxDB:
+go func() {
+	for range time.Tick(time.Second) {
+		// Ignoring any error that could be returned by WriteMeasurement
+		WriteMeasurement(os.Stdout, measurement) // Replace os.Stdout with any io.Writer
+		// Output:
+		// http_event,host=example.local,method=GET,path=/v1/parrots/list count=123i 1136214245000000000
+	}
+}()
+```
+
+The above will keep a count for the number of times `/v1/parrots/list` is accessed, assuming the handler only handles
+that particular path. As a long-term thing, this is fairly useful, because we'd like to know how many people want a list
+of parrots. The imporant thing is that updates to the regular Dagr types, Int, Float, String, and Bool, are atomic: you
+can increment from multiple goroutines and the increment will only block for a minimal amount of time. This also means
+that you can update these fields mid-write without interrupting the write or causing a data race (but you may
+occasionally end up with slightly out of sync fields between two writes).
+
+While the Int and Float types are useful as accumulators, you can also use Bool and String to keep global process state
+up to date in a Point before, allowing you to periodically send whether the process is sleeping or what its current
+stage is (e.g., starting up vs. serving vs. shutting down).
+
+Of course, you could also have short-time stats and allocate and expire them as needed. Dagr doesn't really enforce this
+model, it's just one way I think of things.
+
+
+### Events
+
+An **event**, on the other hand, is something short-lived but worth recording, like a really important error. For example:
+
+```go
+// Setup
+event := dagr.RawPoint{
+	Key: "recv_error",
+	Tag: dagr.Tags{"host": "example.local"},
+	Fields: dagr.Fields{"fatal": dagr.RawBool(true), "message": dagr.RawString("Catastrophic rift in space-time continuum opened")},
+	Time: time.Now(), // if omitted, WriteMeasurement will use time.Now() anyway
+}
+
+// And just send it once (again, ignoring errors)
+WriteMeasurement(os.Stdout, event)
+// Output:
+// http_event,host=example.local fatal=T,message="Catastrophic rift in the space-time continuum opened" 1136214245000000000
+//
+// Note that RawEvent does not guarantee tag or field order, unlike Point, so the above may not be exactly the same
+// every time.
+```
+
+A RawPoint is just a simple Measurement implementation that satisfies the bare minimum needed to write a point in line
+protocol format. It also serves as a decent example for how to begin writing your own points, if necessary. More
+advanced usage can be seen in both Point and PointSet.
+
+Naturally, you may want to alert off of such errors, because a hole in the space time continuum is known to create bunny
+people and generally leads to all sorts of chaos. Point is, these are two different use-cases Dagr was built to
+accomodate, and there are likely more it could handle.
+
+
+## Contributing
+
+If you want to contribute changes, please submit a pull request with a clear description of the changes. As a rule of
+thumb, it's a good idea to create an issue to discuss what you want to do before submitting a pull request, in case
+anyone else is already working on what you're interested in. Anything from bug fixes to documentation to just correcting
+typos is welcome.
+
+**The only requirement to contribute** is that you must add your real name (i.e., the one you'd introduce yourself
+with), an email address you can be contacted at, and optionally a handle or alias to AUTHORS.md. If this places an undue
+burden on you, please send me an email at <ncower@gmail.com> or create a new issue so we can talk about it.
+
+
+## License
+
+Dagr is licensed under the ISC license. You should have received a copy of this license with Dagr in the LICENSE.txt
+file. If not, it is reproduced below:
+
+> Copyright (c) 2015, The Dagr Authors
+>
+> Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby
+> granted, provided that the above copyright notice and this permission notice appear in all copies.
+>
+> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL
+> IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+> INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+> AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+> PERFORMANCE OF THIS SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ that you can update these fields mid-write without interrupting the write or cau
 occasionally end up with slightly out of sync fields between two writes).
 
 While the Int and Float types are useful as accumulators, you can also use Bool and String to keep global process state
-up to date in a Point before, allowing you to periodically send whether the process is sleeping or what its current
-stage is (e.g., starting up vs. serving vs. shutting down).
+up to date in a Point, allowing you to periodically send whether the process is sleeping or what its current stage is
+(e.g., starting up vs. serving vs. shutting down).
 
 Of course, you could also have short-time stats and allocate and expire them as needed. Dagr doesn't really enforce this
 model, it's just one way I think of things.

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ An **event**, on the other hand, is something short-lived but worth recording, l
 ```go
 // Setup
 event := dagr.RawPoint{
-	Key: "recv_error",
-	Tag: dagr.Tags{"host": "example.local"},
+	Key:    "recv_error",
+	Tag:    dagr.Tags{"host": "example.local"},
 	Fields: dagr.Fields{"fatal": dagr.RawBool(true), "message": dagr.RawString("Catastrophic rift in space-time continuum opened")},
-	Time: time.Now(), // if omitted, WriteMeasurement will use time.Now() anyway
+	Time:   time.Now(), // if omitted, WriteMeasurement will use time.Now() anyway
 }
 
 // And just send it once (again, ignoring errors)

--- a/adder.go
+++ b/adder.go
@@ -1,0 +1,46 @@
+package dagr
+
+// IntAdder defines anything that can have an int64 added to itself (e.g., an Int).
+type IntAdder interface {
+	Add(int64)
+}
+
+// FloatAdder defines anything that can have a float64 added to itself (e.g., a Float).
+type FloatAdder interface {
+	Add(float64)
+}
+
+// AddInt adds incr to any field that implements either IntAdder or FloatAdder (by converting incr to a float64) and
+// returns true. If the field doesn't implement either interface, it returns false. This can be used to interact with
+// elements of Fields without requiring you to perform type assertions. If field is nil, it returns false.
+func AddInt(field Field, incr int64) bool {
+	if field == nil {
+		return false
+	}
+	switch f := field.(type) {
+	case IntAdder:
+		f.Add(incr)
+	case FloatAdder:
+		f.Add(float64(incr))
+	default:
+		return false
+	}
+	return true
+}
+
+// AddFloat adds incr to any field that implements either FloatAdder or IntAdder (by converting incr to an int64) and
+// returns true. If the field doesn't implement either interface, it returns false. If field is nil, it returns false.
+func AddFloat(field Field, incr float64) bool {
+	if field == nil {
+		return false
+	}
+	switch f := field.(type) {
+	case IntAdder:
+		f.Add(int64(incr))
+	case FloatAdder:
+		f.Add(incr)
+	default:
+		return false
+	}
+	return true
+}

--- a/compiled.go
+++ b/compiled.go
@@ -1,0 +1,71 @@
+package dagr
+
+import (
+	"io"
+	"time"
+)
+
+type compiledField struct {
+	from, to int
+	value    Field
+}
+
+type compiledPoint struct {
+	prefix []byte
+	lead   int
+	fields []compiledField
+}
+
+var _ = Measurement(compiledPoint{})
+var _ = SnapshotMeasurement(compiledPoint{})
+
+func (c compiledPoint) WriteTo(w io.Writer) (int64, error) {
+	buf := getBuffer(w)
+	head := buf.Len()
+	defer putBuffer(buf)
+
+	buf.Write(c.prefix[:c.lead])
+	for _, f := range c.fields {
+		if f.from < f.to {
+			buf.Write(c.prefix[f.from:f.to])
+		}
+
+		if _, err := f.value.WriteTo(buf); err != nil {
+			buf.Truncate(head)
+			return 0, err
+		}
+	}
+
+	buf.WriteByte(' ')
+	writeTimestamp(buf, clock.Now())
+	buf.WriteByte('\n')
+
+	return buf.WriteTo(w)
+}
+
+// compiledPoints are strictly for io.WriterTo usage and don't support regular Measurement options
+
+func (c compiledPoint) Key() string {
+	return ""
+}
+
+func (c compiledPoint) Fields() map[string]Field {
+	return nil
+}
+
+func (c compiledPoint) Tags() map[string]string {
+	return nil
+}
+
+type fixedCompiledPoint struct {
+	compiledPoint
+	when time.Time
+}
+
+func (f fixedCompiledPoint) Time() time.Time {
+	return f.when
+}
+
+func (c compiledPoint) Snapshot() TimeMeasurement {
+	return fixedCompiledPoint{c, clock.Now()}
+}

--- a/compiled.go
+++ b/compiled.go
@@ -21,7 +21,6 @@ var _ = SnapshotMeasurement(compiledPoint{})
 
 func (c compiledPoint) WriteTo(w io.Writer) (int64, error) {
 	buf := getBuffer(w)
-	head := buf.Len()
 	defer putBuffer(buf)
 
 	buf.Write(c.prefix[:c.lead])
@@ -31,7 +30,7 @@ func (c compiledPoint) WriteTo(w io.Writer) (int64, error) {
 		}
 
 		if _, err := f.value.WriteTo(buf); err != nil {
-			buf.Truncate(head)
+			buf.Truncate(int(buf.head))
 			return 0, err
 		}
 	}

--- a/compiled.go
+++ b/compiled.go
@@ -48,11 +48,11 @@ func (c compiledPoint) Key() string {
 	return ""
 }
 
-func (c compiledPoint) Fields() map[string]Field {
+func (c compiledPoint) Fields() Fields {
 	return nil
 }
 
-func (c compiledPoint) Tags() map[string]string {
+func (c compiledPoint) Tags() Tags {
 	return nil
 }
 

--- a/compiled.go
+++ b/compiled.go
@@ -44,15 +44,15 @@ func (c compiledPoint) WriteTo(w io.Writer) (int64, error) {
 
 // compiledPoints are strictly for io.WriterTo usage and don't support regular Measurement options
 
-func (c compiledPoint) Key() string {
+func (c compiledPoint) GetKey() string {
 	return ""
 }
 
-func (c compiledPoint) Fields() Fields {
+func (c compiledPoint) GetFields() Fields {
 	return nil
 }
 
-func (c compiledPoint) Tags() Tags {
+func (c compiledPoint) GetTags() Tags {
 	return nil
 }
 
@@ -61,7 +61,7 @@ type fixedCompiledPoint struct {
 	when time.Time
 }
 
-func (f fixedCompiledPoint) Time() time.Time {
+func (f fixedCompiledPoint) GetTime() time.Time {
 	return f.when
 }
 

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,11 @@
+// Package dagr is an InfluxDB measurement library.
+//
+// You can use dagr to keeping track of and write primitive types understood by InfluxDB. Measurements are written in
+// line protocol format, per InfluxDB 0.9.x docs:
+//
+// - Line Protocol:        https://influxdb.com/docs/v0.9/write_protocols/line.html
+// - Line Protocol Syntax: https://influxdb.com/docs/v0.9/write_protocols/write_syntax.html
+//
+// dagr has a handful of types, Int, Float, Bool, and String, that allow atomic updates to their values from concurrent
+// goroutines, and a few provisions for writing measurements in line protocol format.
+package dagr

--- a/error.go
+++ b/error.go
@@ -4,8 +4,9 @@ package dagr
 type Error int
 
 const (
-	ErrNoFields = Error(1 + iota) // measurement has no fields
-	ErrEmptyKey
+	ErrNoFields    = Error(1 + iota) // Returned by WriteMeasurement(s) when a measurement has no fields
+	ErrEmptyKey                      // Used to panic when attempting to allocate a point with an empty key
+	ErrNoAllocator                   // Used to panic when attempting to allocate a PointSet with a nil allocator
 )
 
 func (e Error) Error() string {
@@ -16,6 +17,7 @@ func (e Error) Error() string {
 }
 
 var errDescs = map[Error]string{
-	ErrNoFields: "measurement has no fields",
-	ErrEmptyKey: "NewPoint: key is empty",
+	ErrNoFields:    "measurement has no fields",
+	ErrEmptyKey:    "NewPoint: key is empty",
+	ErrNoAllocator: "allocator is nil",
 }

--- a/error.go
+++ b/error.go
@@ -1,0 +1,21 @@
+package dagr
+
+// Error is any error code that is returned by a dagr function or method or might be worth catching a panic on.
+type Error int
+
+const (
+	ErrNoFields = Error(1 + iota) // measurement has no fields
+	ErrEmptyKey
+)
+
+func (e Error) Error() string {
+	if msg, ok := errDescs[e]; ok {
+		return msg
+	}
+	return "unknown error"
+}
+
+var errDescs = map[Error]string{
+	ErrNoFields: "measurement has no fields",
+	ErrEmptyKey: "NewPoint: key is empty",
+}

--- a/field.go
+++ b/field.go
@@ -81,6 +81,7 @@ func (b *Bool) UnmarshalJSON(js []byte) error {
 type Int int64
 
 var _ = Field((*Int)(nil))
+var _ = IntAdder((*Int)(nil))
 var _ = json.Marshaler((*Int)(nil))
 var _ = json.Unmarshaler((*Int)(nil))
 
@@ -175,6 +176,7 @@ func (n *Int) UnmarshalJSON(in []byte) error {
 type Float uint64
 
 var _ = Field((*Float)(nil))
+var _ = FloatAdder((*Float)(nil))
 var _ = json.Marshaler((*Float)(nil))
 var _ = json.Unmarshaler((*Float)(nil))
 

--- a/field.go
+++ b/field.go
@@ -1,0 +1,387 @@
+package dagr
+
+import (
+	"encoding/json"
+	"io"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync/atomic"
+)
+
+// Field is any field value an InfluxDB measurement may hold. Fields must be duplicate-able (e.g., for snapshotting and
+// such). Methods that modify field state must be safe for use across multiple goroutines. If the type implementing
+// Field does not have mutable state, it is considered read-only.
+//
+// In order to keep fields and their names separate, Field is not responsible for writing its name, and should not
+// attempt to write a name, only its value.
+type Field interface {
+	Dup() Field
+	io.WriterTo
+}
+
+// Bool is a Field that stores an InfluxDB boolean value. When written, it is encoded as either T or F, depending on its
+// value. Its zero value is false.
+type Bool uint32
+
+var _ = Field((*Bool)(nil))
+var _ = json.Marshaler((*Bool)(nil))
+var _ = json.Unmarshaler((*Bool)(nil))
+
+func (b *Bool) ptr() *uint32 {
+	return (*uint32)(b)
+}
+
+func (b *Bool) sample() bool {
+	return atomic.LoadUint32(b.ptr()) != 0
+}
+
+// Set sets the Bool's value to new.
+func (b *Bool) Set(new bool) {
+	var i uint32
+	if new {
+		i = 1
+	}
+	atomic.StoreUint32(b.ptr(), i)
+}
+
+func (b *Bool) Snapshot() Field {
+	return fixedBool(b.sample())
+}
+
+func (b *Bool) Dup() Field {
+	q := Bool(atomic.LoadUint32(b.ptr()))
+	return &q
+}
+
+func (b *Bool) WriteTo(w io.Writer) (int64, error) {
+	return fixedBool(b.sample()).WriteTo(w)
+}
+
+func (b *Bool) MarshalJSON() ([]byte, error) {
+	if b.sample() {
+		return []byte{'t', 'r', 'u', 'e'}, nil
+	} else {
+		return []byte{'f', 'a', 'l', 's', 'e'}, nil
+	}
+}
+
+func (b *Bool) UnmarshalJSON(js []byte) error {
+	var new bool
+	if err := json.Unmarshal(js, new); err != nil {
+		return err
+	}
+	b.Set(new)
+	return nil
+}
+
+// Int is a Field that stores an InfluxDB integer value. When written, it's encoded as a 64-bit integer with the 'i'
+// suffix, per InfluxDB documentation (e.g., "123456i" sans quotes).
+type Int int64
+
+var _ = Field((*Int)(nil))
+var _ = json.Marshaler((*Int)(nil))
+var _ = json.Unmarshaler((*Int)(nil))
+
+func (n *Int) ptr() *int64 {
+	return (*int64)(n)
+}
+
+func (n *Int) sample() int64 {
+	return atomic.LoadInt64(n.ptr())
+}
+
+// Add adds incr to the value held by the Int.
+func (n *Int) Add(incr int64) {
+	atomic.AddInt64(n.ptr(), incr)
+}
+
+// Set sets the value held by the Int.
+func (n *Int) Set(new int64) {
+	atomic.StoreInt64(n.ptr(), new)
+}
+
+func (n *Int) Snapshot() Field {
+	return fixedInt(n.sample())
+}
+
+func (n *Int) Dup() Field {
+	i := Int(n.sample())
+	return &i
+}
+
+func (n *Int) WriteTo(w io.Writer) (int64, error) {
+	return fixedInt(n.sample()).WriteTo(w)
+}
+
+func (n *Int) MarshalJSON() ([]byte, error) {
+	return json.Marshal(n.sample())
+}
+
+func badJSONValue(in []byte) string {
+	switch in[0] {
+	case '{':
+		return "object"
+	case '[':
+		return "array"
+	case 'n':
+		return "null"
+	case 't':
+		return "true"
+	case 'f':
+		return "false"
+	case '"':
+		return "string"
+	default:
+		return "number " + string(in)
+	}
+}
+
+func (n *Int) UnmarshalJSON(in []byte) error {
+	if len(in) == 0 {
+		return &json.UnmarshalTypeError{"empty JSON", reflect.TypeOf(n), 0}
+	}
+
+	var err error
+	var next int64
+	switch in[0] {
+	case 'n', 't', 'f', '{', '[':
+		return &json.UnmarshalTypeError{badJSONValue(in), reflect.TypeOf(n), 0}
+	case '"':
+		var new json.Number
+		err = json.Unmarshal(in, &new)
+		if err == nil {
+			next, err = new.Int64()
+
+			if err != nil {
+				err = &json.UnmarshalTypeError{"quoted number " + new.String(), reflect.TypeOf(n), 0}
+			}
+		}
+	default:
+		err = json.Unmarshal(in, &next)
+	}
+
+	if err == nil {
+		n.Set(next)
+	}
+
+	return nil
+}
+
+// Float is a Field that stores an InfluxDB float value. When written, it's encoded as a float64 using as few digits as
+// possible (i.e., its precision is -1 when passed to FormatFloat). Different behavior may be desirable, in which case
+// it's necessary to implement your own float field. Updates to Float are atomic.
+type Float uint64
+
+var _ = Field((*Float)(nil))
+var _ = json.Marshaler((*Float)(nil))
+var _ = json.Unmarshaler((*Float)(nil))
+
+func (f *Float) ptr() *uint64 {
+	return (*uint64)(f)
+}
+
+func (f *Float) sample() float64 {
+	return math.Float64frombits(atomic.LoadUint64(f.ptr()))
+}
+
+func (f *Float) tryAdd(incr float64) bool {
+	p := f.ptr()
+	old := atomic.LoadUint64(p)
+	new := math.Float64bits(math.Float64frombits(old) + incr)
+	return atomic.CompareAndSwapUint64(p, old, new)
+}
+
+// Add adds incr to the value held by Float.
+func (f *Float) Add(incr float64) {
+	for !f.tryAdd(incr) {
+	}
+}
+
+// Set sets the Float's value to new.
+func (f *Float) Set(new float64) {
+	atomic.StoreUint64(f.ptr(), math.Float64bits(new))
+}
+
+func (f *Float) Snapshot() Field {
+	return fixedFloat(f.sample())
+}
+
+func (f *Float) Dup() Field {
+	n := Float(atomic.LoadUint64(f.ptr()))
+	return &n
+}
+
+func (f *Float) WriteTo(w io.Writer) (int64, error) {
+	return fixedFloat(f.sample()).WriteTo(w)
+}
+
+func (f *Float) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.sample())
+}
+
+func (f *Float) UnmarshalJSON(in []byte) error {
+	if len(in) == 0 {
+		return &json.UnmarshalTypeError{"number", reflect.TypeOf(f), 0}
+	}
+
+	var err error
+	var next float64
+	switch in[0] {
+	case 'n', 't', 'f', '{', '[':
+		return &json.UnmarshalTypeError{badJSONValue(in), reflect.TypeOf(f), 0}
+	case '"':
+		var new json.Number
+		err = json.Unmarshal(in, &new)
+		if err == nil {
+			next, err = new.Float64()
+
+			if err != nil {
+				err = &json.UnmarshalTypeError{"quoted number " + new.String(), reflect.TypeOf(f), 0}
+			}
+		}
+	default:
+		err = json.Unmarshal(in, &next)
+	}
+
+	if err == nil {
+		f.Set(next)
+	}
+
+	return err
+}
+
+// String is a Field that stores an InfluxDB string value.
+type String struct {
+	value atomic.Value
+}
+
+var (
+	stringUnescaper = strings.NewReplacer(`\"`, `"`)
+	stringEscaper   = strings.NewReplacer(`"`, `\"`)
+
+	_ = Field((*String)(nil))
+	_ = json.Marshaler((*String)(nil))
+	_ = json.Unmarshaler((*String)(nil))
+)
+
+// Set sets the String's value to new.
+func (s *String) Set(new string) {
+	// Limit stored values to 64kb -- this should still point to the same memory backing the string.
+	if len(new) > 64000 {
+		new = new[:64000]
+	}
+	s.value.Store([]byte(`"` + stringEscaper.Replace(new) + `"`))
+}
+
+func (s *String) sample() []byte {
+	b, _ := s.value.Load().([]byte)
+	return b
+}
+
+func (s *String) Snapshot() Field {
+	return fixedString(s.sample())
+}
+
+func (s *String) Dup() Field {
+	b := s.sample()
+	s = new(String)
+	s.value.Store(b)
+	return s
+}
+
+func (s *String) WriteTo(w io.Writer) (int64, error) {
+	// I could store this encoded and it might make a small difference, but I'm treating sets as the common case and
+	// writes as the uncommon case. Basically, I expect write-outs of fields to only occur as often as once every
+	// 500ms at its most frequent (you could do more, but strings are already pretty unlikely to be used, I figure).
+	// More likely, you'll be writing once every 5s or 10s, in which case, the time taken to do a replacement is
+	// fairly low in comparison, assuming the string itself is small enough.
+	n, err := w.Write(s.sample())
+	return int64(n), err
+}
+
+func (s *String) MarshalJSON() ([]byte, error) {
+	b := s.sample()
+	b = b[1 : len(b)-1]
+	return json.Marshal(stringUnescaper.Replace(string(b)))
+}
+
+func (s *String) UnmarshalJSON(in []byte) error {
+	var new string
+	if err := json.Unmarshal(in, &new); err != nil {
+		return err
+	}
+	s.Set(new)
+	return nil
+}
+
+// Fixed types
+// These are used primarily for snapshotting, since
+
+type (
+	fixedBool   bool
+	fixedFloat  float64
+	fixedInt    int64
+	fixedString []byte
+)
+
+func (f fixedBool) Dup() Field { return f }
+
+func (f fixedBool) MarshalJSON() ([]byte, error) {
+	if f {
+		return []byte{'t', 'r', 'u', 'e'}, nil
+	} else {
+		return []byte{'f', 'a', 'l', 's', 'e'}, nil
+	}
+}
+
+func (f fixedBool) WriteTo(w io.Writer) (n int64, err error) {
+	var c byte = 'F'
+	if f {
+		c = 'T'
+	}
+
+	err = writeByte(w, c)
+	if err == nil {
+		n = 1
+	}
+	return n, err
+}
+
+func (f fixedInt) Dup() Field { return f }
+
+func (f fixedInt) MarshalJSON() ([]byte, error) {
+	return json.Marshal(int64(f))
+}
+
+func (f fixedInt) WriteTo(w io.Writer) (int64, error) {
+	var buf [20]byte
+	b := append(strconv.AppendInt(buf[0:0], int64(f), 10), 'i')
+	wn, err := w.Write(b)
+	return int64(wn), err
+}
+
+func (f fixedFloat) Dup() Field { return f }
+
+func (f fixedFloat) MarshalJSON() ([]byte, error) {
+	return json.Marshal(float64(f))
+}
+
+func (f fixedFloat) WriteTo(w io.Writer) (int64, error) {
+	var buf [32]byte
+	b := strconv.AppendFloat(buf[0:0], float64(f), 'f', -1, 64)
+	n, err := w.Write(b)
+	return int64(n), err
+}
+
+func (f fixedString) Dup() Field { return f }
+
+func (s fixedString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(stringUnescaper.Replace(string(s[1 : len(s)-1])))
+}
+
+func (s fixedString) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write([]byte(s))
+	return int64(n), err
+}

--- a/field.go
+++ b/field.go
@@ -140,14 +140,14 @@ func badJSONValue(in []byte) string {
 
 func (n *Int) UnmarshalJSON(in []byte) error {
 	if len(in) == 0 {
-		return &json.UnmarshalTypeError{"empty JSON", reflect.TypeOf(n), 0}
+		return &json.UnmarshalTypeError{Value: "empty JSON", Type: reflect.TypeOf(n)}
 	}
 
 	var err error
 	var next int64
 	switch in[0] {
 	case 'n', 't', 'f', '{', '[':
-		return &json.UnmarshalTypeError{badJSONValue(in), reflect.TypeOf(n), 0}
+		return &json.UnmarshalTypeError{Value: badJSONValue(in), Type: reflect.TypeOf(n)}
 	case '"':
 		var new json.Number
 		err = json.Unmarshal(in, &new)
@@ -155,7 +155,7 @@ func (n *Int) UnmarshalJSON(in []byte) error {
 			next, err = new.Int64()
 
 			if err != nil {
-				err = &json.UnmarshalTypeError{"quoted number " + new.String(), reflect.TypeOf(n), 0}
+				err = &json.UnmarshalTypeError{Value: "quoted number " + new.String(), Type: reflect.TypeOf(n)}
 			}
 		}
 	default:
@@ -223,14 +223,14 @@ func (f *Float) MarshalJSON() ([]byte, error) {
 
 func (f *Float) UnmarshalJSON(in []byte) error {
 	if len(in) == 0 {
-		return &json.UnmarshalTypeError{"number", reflect.TypeOf(f), 0}
+		return &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(f)}
 	}
 
 	var err error
 	var next float64
 	switch in[0] {
 	case 'n', 't', 'f', '{', '[':
-		return &json.UnmarshalTypeError{badJSONValue(in), reflect.TypeOf(f), 0}
+		return &json.UnmarshalTypeError{Value: badJSONValue(in), Type: reflect.TypeOf(f)}
 	case '"':
 		var new json.Number
 		err = json.Unmarshal(in, &new)
@@ -238,7 +238,7 @@ func (f *Float) UnmarshalJSON(in []byte) error {
 			next, err = new.Float64()
 
 			if err != nil {
-				err = &json.UnmarshalTypeError{"quoted number " + new.String(), reflect.TypeOf(f), 0}
+				err = &json.UnmarshalTypeError{Value: "quoted number " + new.String(), Type: reflect.TypeOf(f)}
 			}
 		}
 	default:

--- a/json.go
+++ b/json.go
@@ -1,0 +1,70 @@
+package dagr
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+type jsonField struct {
+	name  string
+	value interface{}
+}
+
+type jsonFields []jsonField
+
+func makeJSONFields(fields map[string]Field, order []string) jsonFields {
+	fs := make([]jsonField, len(order))
+	for i, name := range order {
+		fs[i] = jsonField{name, fields[name]}
+	}
+	return fs
+}
+
+func makeJSONTags(tags map[string]string, order []string) jsonFields {
+	fs := make([]jsonField, len(order))
+	for i, name := range order {
+		fs[i] = jsonField{name, tags[name]}
+	}
+	return fs
+}
+
+func (fs jsonFields) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+
+	var err error
+	enc := json.NewEncoder(&buf)
+	write := func(v interface{}) {
+		if err != nil {
+			return
+		}
+
+		n := buf.Len()
+		if err = enc.Encode(v); err != nil {
+			return
+		}
+
+		if l := buf.Len(); l > n {
+			buf.Truncate(l - 1)
+		}
+	}
+
+	for i, f := range fs {
+		if err != nil {
+			return nil, err
+		}
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		write(f.name)
+		buf.WriteByte(':')
+		write(f.value)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	buf.WriteByte('}')
+
+	return buf.Bytes(), nil
+}

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,73 @@
+package dagr
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"testing"
+)
+
+func ExampleMarshalJSON() {
+	integer := new(Int)
+	boolean := new(Bool)
+	float := new(Float)
+	str := new(String)
+
+	integer.Set(123)
+	boolean.Set(true)
+	float.Set(123.456)
+	str.Set(`a "string" of sorts`)
+
+	m := NewPoint(
+		"service.some_event",
+		Tags{"pid": fmt.Sprint(1234), "host": "example.local"},
+		Fields{"value": integer, "depth": float, "on": boolean, "msg": str},
+	)
+
+	bs, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%s", bs)
+	// Output:
+	// {
+	//   "Key": "service.some_event",
+	//   "Timestamp": "1136214245000000000",
+	//   "Tags": {
+	//     "depth": 123.456,
+	//     "msg": "a \"string\" of sorts",
+	//     "on": true,
+	//     "value": 123
+	//   },
+	//   "Fields": {
+	//     "host": "example.local",
+	//     "pid": "1234"
+	//   }
+	// }
+}
+
+func BenchmarkJSONMeasurement(b *testing.B) {
+	integer := new(Int)
+	boolean := new(Bool)
+	float := new(Float)
+	str := new(String)
+
+	integer.Set(123)
+	boolean.Set(true)
+	float.Set(123.456)
+	str.Set(`a "string" of sorts`)
+
+	m := NewPoint(
+		"service.some_event",
+		Tags{"pid": fmt.Sprint(1234), "host": "example.local"},
+		Fields{"value": integer, "depth": float, "on": boolean, "msg": str},
+	)
+
+	enc := json.NewEncoder(ioutil.Discard)
+	for i := b.N; i > 0; i-- {
+		if err := enc.Encode(m); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/json_test.go
+++ b/json_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func ExampleMarshalJSON() {
+func ExamplePoint_MarshalJSON() {
 	integer := new(Int)
 	boolean := new(Bool)
 	float := new(Float)

--- a/log.go
+++ b/log.go
@@ -1,0 +1,23 @@
+package dagr
+
+import "log"
+
+type Logger interface {
+	Printf(string, ...interface{})
+}
+
+type defaultLogger struct{}
+
+func (defaultLogger) Printf(f string, v ...interface{}) {
+	log.Printf(f, v...)
+}
+
+type discardLogger struct{}
+
+func (discardLogger) Printf(string, ...interface{}) {}
+
+var (
+	DiscardLogger        = discardLogger{}
+	StdLogger            = defaultLogger{}
+	Log           Logger = DiscardLogger
+)

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,17 @@
+package dagr
+
+type tLogf func(string, ...interface{})
+
+func (fn tLogf) Printf(f string, v ...interface{}) { fn(f, v...) }
+
+type testLogger interface {
+	Logf(string, ...interface{})
+}
+
+func prepareLogger(t testLogger) func() {
+	temp := Log
+	Log = tLogf(t.Logf)
+	return func() {
+		Log = temp
+	}
+}

--- a/measurement.go
+++ b/measurement.go
@@ -1,0 +1,324 @@
+package dagr
+
+import (
+	"encoding/json"
+	"io"
+	"sort"
+	"sync"
+	"time"
+)
+
+type Tags map[string]string
+
+type Fields map[string]Field
+
+// Measurement defines the minimum interface for a measurement that could be passed to InfluxDB. All measurements must
+// have a key and a minimum of one field. Tags are optional.
+//
+// Unless stated otherwise, the results of Tags and Fields are considered immutable.
+type Measurement interface {
+	Key() string
+	Tags() map[string]string
+	Fields() map[string]Field
+}
+
+// TimeMeasurement is a measurement that has a known, known, fixed time. It can be considered a measurement that is
+// fixed to a specific point in time. TimeMeasurements are not necessarily read-only and may, for example, return
+// time.Now(). In general, it is better to not implement TimeMeasurement if your measurement is returning time.Now().
+type TimeMeasurement interface {
+	Time() time.Time
+
+	Measurement
+}
+
+type fixedField struct {
+	prefix []byte
+	fields []fixedField
+}
+
+// Point is a single Measurement as understood by InfluxDB.
+type Point struct {
+	key        string
+	tagOrder   []string
+	fieldOrder []string
+	tags       map[string]string
+	fields     map[string]Field
+	m          sync.RWMutex
+}
+
+var _ = Measurement((*Point)(nil))
+
+// NewPoint allocates a new Point with the given key, tags, and fields. If key is empty, NewPoint panics. If fields is
+// empty, the point cannot be written until it has at least one field.
+func NewPoint(key string, tags map[string]string, fields map[string]Field) *Point {
+	if key == "" {
+		panic("dagr.NewPoint: key is empty")
+	}
+
+	p := &Point{
+		key:    key,
+		tags:   make(map[string]string, len(tags)),
+		fields: make(map[string]Field, len(fields)),
+	}
+
+	for name, tag := range tags {
+		p.addTag(name, tag)
+	}
+
+	for name, field := range fields {
+		p.addField(name, field)
+	}
+
+	return p
+}
+
+// WriteTo writes the point to the given writer, w. If an error occurs while building the point, it writes nothing and
+// return an error. If the point has no fields, it returns the error ErrNoFields.
+func (p *Point) WriteTo(w io.Writer) (int64, error) {
+	buf := getBuffer(w)
+	head := buf.Len()
+	p.m.RLock()
+	defer func() {
+		p.m.RUnlock()
+		putBuffer(buf)
+	}()
+
+	buf.WriteString(tagEscaper.Replace(p.key))
+	writeTags(buf, p.tags, p.tagOrder)
+
+	buf.WriteByte(' ')
+	if err := writeFields(buf, p.fields, p.fieldOrder); err != nil {
+		buf.Truncate(head)
+		return 0, err
+	}
+
+	buf.WriteByte(' ')
+	writeTimestamp(buf, clock.Now())
+	buf.WriteByte('\n')
+
+	return buf.WriteTo(w)
+}
+
+// Key returns the point's key.
+func (p *Point) Key() string {
+	return p.key
+}
+
+// Compiled returns a compiled form of the point. The resulting Measurement is immutable except for its field values.
+// New fields may not be added and it will not return a key, tags, or values. The compiled form of a point is only
+// useful to improve write times on points when necessary. If the point has no fields, it returns nil, as the point is
+// not valid to write.
+func (p *Point) Compiled() Measurement {
+	p.m.RLock()
+	p.m.RUnlock()
+
+	if len(p.fieldOrder) == 0 {
+		return nil
+	}
+	return p.compile()
+}
+
+func (p *Point) compile() compiledPoint {
+	var c compiledPoint
+	buf := getBuffer(nil)
+	defer putBuffer(buf)
+
+	// Write key
+	buf.WriteString(tagEscaper.Replace(p.key))
+	// Write tags
+	writeTags(buf, p.tags, p.tagOrder)
+	c.lead = buf.Len()
+	// Write field names
+	var pre byte = ' '
+	fields := make([]compiledField, len(p.fieldOrder))
+	for i, name := range p.fieldOrder {
+		field := p.fields[name]
+
+		from := buf.Len()
+		buf.WriteByte(pre)
+		pre = ','
+
+		buf.WriteString(tagEscaper.Replace(name))
+		buf.WriteByte('=')
+
+		to := buf.Len()
+		if i == 0 {
+			from = to
+			c.lead = to
+		}
+		fields[i] = compiledField{from, to, field}
+	}
+
+	c.prefix = append([]byte(nil), buf.Bytes()...)
+	c.fields = fields
+
+	return c
+}
+
+// Tags
+
+func (p *Point) dupTags() map[string]string {
+	tags := make(map[string]string, len(p.tags))
+	for name, tag := range p.tags {
+		tags[name] = tag
+	}
+	return tags
+}
+
+func (p *Point) addTag(name, value string) {
+	_, exists := p.tags[name]
+	p.tags[name] = value
+	if exists {
+		return
+	}
+	p.tagOrder = insertOrderedString(p.tagOrder, name)
+}
+
+// SetTag sets a tag on the point with the given name and value. If the value is empty, the tag is removed. If the name
+// is empty, the call is a no-op. It is safe to call SetTag from concurrent goroutines.
+func (p *Point) SetTag(name, value string) {
+	if name == "" {
+		return
+	} else if value == "" {
+		p.RemoveTag(name)
+		return
+	}
+
+	p.m.Lock()
+	defer p.m.Unlock()
+	p.addTag(name, value)
+}
+
+// RemoveTag removes the tag with the given name from the point. If name is empty, the call is a no-op. It is safe to
+// call from concurrent goroutines.
+func (p *Point) RemoveTag(name string) {
+	if name == "" {
+		return
+	}
+
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if _, ok := p.tags[name]; !ok {
+		// No tag
+		return
+	}
+
+	delete(p.tags, name)
+	for i, tname := range p.tagOrder {
+		if name == tname {
+			copy(p.tagOrder[i:], p.tagOrder[i+1:])
+			p.tagOrder = p.tagOrder[:len(p.tagOrder)-1]
+			break
+		}
+	}
+}
+
+// Tags returns a copy of the point's tags as a map of names to values. Names and values are not escaped. It is safe to
+// copy and modify the result of this method.
+func (p *Point) Tags() map[string]string {
+	p.m.RLock()
+	defer p.m.RUnlock()
+	return p.dupTags()
+}
+
+// Fields
+
+// insertOrderedString inserts str in the ordered slice of strings. It assumes that all elements of slice are unique,
+// though this isn't necessarily important except that having non-unique names would result in Point having a memory
+// leak.
+func insertOrderedString(slice []string, str string) []string {
+	n := len(slice)
+	if idx := sort.SearchStrings(slice, str); idx < n {
+		slice = append(slice, "")
+		copy(slice[idx+1:], slice[idx:n])
+		slice[idx] = str
+	} else {
+		slice = append(slice, str)
+	}
+	return slice
+}
+
+func (p *Point) addField(name string, value Field) {
+	_, exists := p.fields[name]
+	p.fields[name] = value
+	if exists {
+		return
+	}
+	p.fieldOrder = insertOrderedString(p.fieldOrder, name)
+}
+
+// SetField sets a field with the given name and value. If name is empty, the call is a no-op. If value is nil, it
+// removes the field.
+func (p *Point) SetField(name string, value Field) {
+	if name == "" {
+		return
+	} else if value == nil {
+		p.RemoveField(name)
+		return
+	}
+
+	p.m.Lock()
+	defer p.m.Unlock()
+	p.addField(name, value)
+}
+
+// RemoveField removes a field with the given name. If name is empty, the call is a no-op. It is safe to call
+// RemoveField from concurrent goroutines.
+func (p *Point) RemoveField(name string) {
+	if name == "" {
+		return
+	}
+
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if _, ok := p.fields[name]; !ok {
+		// No field
+		return
+	}
+
+	delete(p.fields, name)
+	for i, fname := range p.fieldOrder {
+		if name == fname {
+			copy(p.fieldOrder[i:], p.fieldOrder[i+1:])
+			p.fieldOrder = p.fieldOrder[:len(p.fieldOrder)-1]
+			break
+		}
+	}
+}
+
+func (p *Point) dupFields() map[string]Field {
+	fields := make(map[string]Field, len(p.fields))
+	for name, field := range p.fields {
+		fields[name] = field
+	}
+	return fields
+}
+
+// Fields returns a map of the point's fields. This map is a copy of the point's state and may be modified without
+// affecting the point. The fields themselves are those held by the point, however, and modifying them will modify the
+// point's state.
+func (p *Point) Fields() map[string]Field {
+	p.m.RLock()
+	defer p.m.RUnlock()
+	return p.dupFields()
+}
+
+func (p *Point) MarshalJSON() ([]byte, error) {
+	p.m.RLock()
+	defer p.m.RUnlock()
+	jsonPoint := struct {
+		Key       string
+		Timestamp int64 `json:",string"`
+		Tags      jsonFields
+		Fields    jsonFields
+	}{
+		p.key,
+		clock.Now().UnixNano(),
+		makeJSONFields(p.fields, p.fieldOrder),
+		makeJSONTags(p.tags, p.tagOrder),
+	}
+
+	return json.Marshal(jsonPoint)
+}

--- a/measurement.go
+++ b/measurement.go
@@ -76,7 +76,6 @@ func NewPoint(key string, tags map[string]string, fields map[string]Field) *Poin
 // return an error. If the point has no fields, it returns the error ErrNoFields.
 func (p *Point) WriteTo(w io.Writer) (int64, error) {
 	buf := getBuffer(w)
-	head := buf.Len()
 	p.m.RLock()
 	defer func() {
 		p.m.RUnlock()
@@ -88,7 +87,7 @@ func (p *Point) WriteTo(w io.Writer) (int64, error) {
 
 	buf.WriteByte(' ')
 	if err := writeFields(buf, p.fields, p.fieldOrder); err != nil {
-		buf.Truncate(head)
+		buf.Truncate(int(buf.head))
 		return 0, err
 	}
 

--- a/measurement.go
+++ b/measurement.go
@@ -47,16 +47,16 @@ func (fs Fields) Dup(deep bool) Fields {
 //
 // Unless stated otherwise, the results of Tags and Fields are considered immutable.
 type Measurement interface {
-	Key() string
-	Tags() Tags
-	Fields() Fields
+	GetKey() string
+	GetTags() Tags
+	GetFields() Fields
 }
 
 // TimeMeasurement is a measurement that has a known, known, fixed time. It can be considered a measurement that is
 // fixed to a specific point in time. TimeMeasurements are not necessarily read-only and may, for example, return
 // time.Now(). In general, it is better to not implement TimeMeasurement if your measurement is returning time.Now().
 type TimeMeasurement interface {
-	Time() time.Time
+	GetTime() time.Time
 
 	Measurement
 }
@@ -128,8 +128,8 @@ func (p *Point) WriteTo(w io.Writer) (int64, error) {
 	return buf.WriteTo(w)
 }
 
-// Key returns the point's key.
-func (p *Point) Key() string {
+// GetKey returns the point's key.
+func (p *Point) GetKey() string {
 	return p.key
 }
 
@@ -235,9 +235,9 @@ func (p *Point) RemoveTag(name string) {
 	}
 }
 
-// Tags returns a copy of the point's tags as a map of names to values. Names and values are not escaped. It is safe to
-// copy and modify the result of this method.
-func (p *Point) Tags() Tags {
+// GetTags returns a copy of the point's tags as a map of names to values. Names and values are not escaped. It is safe
+// to copy and modify the result of this method.
+func (p *Point) GetTags() Tags {
 	p.m.RLock()
 	defer p.m.RUnlock()
 	return Tags(p.tags).Dup()
@@ -309,10 +309,10 @@ func (p *Point) RemoveField(name string) {
 	}
 }
 
-// Fields returns a map of the point's fields. This map is a copy of the point's state and may be modified without
+// GetFields returns a map of the point's fields. This map is a copy of the point's state and may be modified without
 // affecting the point. The fields themselves are those held by the point, however, and modifying them will modify the
 // point's state.
-func (p *Point) Fields() Fields {
+func (p *Point) GetFields() Fields {
 	p.m.RLock()
 	defer p.m.RUnlock()
 	return Fields(p.fields).Dup(false)

--- a/measurement.go
+++ b/measurement.go
@@ -309,10 +309,6 @@ func (p *Point) RemoveField(name string) {
 	}
 }
 
-func (p *Point) dupFields() Fields {
-	return Fields(p.fields).Dup(false)
-}
-
 // Fields returns a map of the point's fields. This map is a copy of the point's state and may be modified without
 // affecting the point. The fields themselves are those held by the point, however, and modifying them will modify the
 // point's state.

--- a/measurement_example_test.go
+++ b/measurement_example_test.go
@@ -30,7 +30,7 @@ func ExampleWriteMeasurement() {
 // Compiled measurements can be used to speed up encoding if you're frequently writing a large number of measurements.
 // In most cases, this is entirely unnecessary. Compiled measurements only update their field values and are otherwise
 // immutable.
-func ExampleWriteCompiledMeasurement() {
+func ExampleWriteMeasurement_compiled() {
 	integer := new(Int)
 	boolean := new(Bool)
 	float := new(Float)

--- a/measurement_example_test.go
+++ b/measurement_example_test.go
@@ -1,0 +1,53 @@
+package dagr
+
+import (
+	"fmt"
+	"os"
+)
+
+func ExampleWriteMeasurement() {
+	integer := new(Int)
+	boolean := new(Bool)
+	float := new(Float)
+	str := new(String)
+
+	integer.Set(123)
+	boolean.Set(true)
+	float.Set(123.456)
+	str.Set(`a "string" of sorts`)
+
+	m := NewPoint(
+		"service.some_event",
+		Tags{"pid": fmt.Sprint(1234), "host": "example.local"},
+		Fields{"value": integer, "depth": float, "on": boolean, "msg": str},
+	)
+
+	WriteMeasurement(os.Stdout, m)
+	// Output:
+	// service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000
+}
+
+// Compiled measurements can be used to speed up encoding if you're frequently writing a large number of measurements.
+// In most cases, this is entirely unnecessary. Compiled measurements only update their field values and are otherwise
+// immutable.
+func ExampleWriteCompiledMeasurement() {
+	integer := new(Int)
+	boolean := new(Bool)
+	float := new(Float)
+	str := new(String)
+
+	integer.Set(123)
+	boolean.Set(true)
+	float.Set(123.456)
+	str.Set(`a "string" of sorts`)
+
+	m := NewPoint(
+		"service.some_event",
+		Tags{"pid": fmt.Sprint(1234), "host": "example.local"},
+		Fields{"value": integer, "depth": float, "on": boolean, "msg": str},
+	).Compiled()
+
+	WriteMeasurement(os.Stdout, m)
+	// Output:
+	// service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000
+}

--- a/measurement_test.go
+++ b/measurement_test.go
@@ -1,0 +1,153 @@
+package dagr
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"testing"
+)
+
+func TestCompiledPoint(t *testing.T) {
+	const required = `service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000` + "\n"
+
+	integer := new(Int)
+	boolean := new(Bool)
+	float := new(Float)
+	str := new(String)
+
+	integer.Set(123)
+	boolean.Set(true)
+	float.Set(123.456)
+	str.Set(`a "string" of sorts`)
+
+	var rb bytes.Buffer
+	m := NewPoint(
+		"service.some_event",
+		Tags{"pid": fmt.Sprint(1234), "host": "example.local"},
+		Fields{"value": integer, "depth": float, "on": boolean, "msg": str},
+	)
+
+	if _, err := m.WriteTo(&rb); err != nil {
+		t.Fatal(err)
+	}
+
+	normal := rb.String()
+	if normal != required {
+		t.Errorf("[N] Expected %q\nGot %q", required, normal)
+	}
+
+	c := m.compile()
+	var cb bytes.Buffer
+	if _, err := c.WriteTo(&cb); err != nil {
+		t.Fatal(err)
+	}
+
+	compiled := cb.String()
+	if compiled != required {
+		t.Errorf("[C] Expected %q\nGot %q", required, compiled)
+	}
+
+	if compiled != normal {
+		t.Errorf("[CN] Expected %q\nGot %q", normal, compiled)
+	}
+}
+
+func BenchmarkWriteMeasurement(b *testing.B) {
+	const result = `service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000` + "\n"
+
+	integer := new(Int)
+	boolean := new(Bool)
+	float := new(Float)
+	str := new(String)
+
+	integer.Set(123)
+	boolean.Set(true)
+	float.Set(123.456)
+	str.Set(`a "string" of sorts`)
+
+	m := NewPoint(
+		"service.some_event",
+		Tags{"pid": fmt.Sprint(1234), "host": "example.local"},
+		Fields{"value": integer, "depth": float, "on": boolean, "msg": str},
+	)
+
+	for i := b.N; i > 0; i-- {
+		WriteMeasurement(ioutil.Discard, m)
+	}
+}
+
+func BenchmarkWriteMeasurement_Compiled(b *testing.B) {
+	const result = `service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000` + "\n"
+
+	integer := new(Int)
+	boolean := new(Bool)
+	float := new(Float)
+	str := new(String)
+
+	integer.Set(123)
+	boolean.Set(true)
+	float.Set(123.456)
+	str.Set(`a "string" of sorts`)
+
+	m := NewPoint(
+		"service.some_event",
+		Tags{"pid": fmt.Sprint(1234), "host": "example.local"},
+		Fields{"value": integer, "depth": float, "on": boolean, "msg": str},
+	).Compiled()
+
+	for i := b.N; i > 0; i-- {
+		WriteMeasurement(ioutil.Discard, m)
+	}
+}
+
+func BenchmarkWriteMeasurement_Parallel(b *testing.B) {
+	const result = `service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000` + "\n"
+
+	integer := new(Int)
+	boolean := new(Bool)
+	float := new(Float)
+	str := new(String)
+
+	integer.Set(123)
+	boolean.Set(true)
+	float.Set(123.456)
+	str.Set(`a "string" of sorts`)
+
+	m := NewPoint(
+		"service.some_event",
+		Tags{"pid": fmt.Sprint(1234), "host": "example.local"},
+		Fields{"value": integer, "depth": float, "on": boolean, "msg": str},
+	)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			WriteMeasurement(ioutil.Discard, m)
+		}
+	})
+}
+
+func BenchmarkWriteMeasurement_ParallelCompiled(b *testing.B) {
+	const result = `service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000` + "\n"
+
+	integer := new(Int)
+	boolean := new(Bool)
+	float := new(Float)
+	str := new(String)
+
+	integer.Set(123)
+	boolean.Set(true)
+	float.Set(123.456)
+	str.Set(`a "string" of sorts`)
+
+	m := NewPoint(
+		"service.some_event",
+		Tags{"pid": fmt.Sprint(1234), "host": "example.local"},
+		Fields{"value": integer, "depth": float, "on": boolean, "msg": str},
+	).Compiled()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			WriteMeasurement(ioutil.Discard, m)
+		}
+	})
+}

--- a/measurement_test.go
+++ b/measurement_test.go
@@ -7,6 +7,25 @@ import (
 	"testing"
 )
 
+func TestWriteEmptyMeasurement(t *testing.T) {
+	defer prepareLogger(t)()
+
+	var rb bytes.Buffer
+	m := NewPoint(
+		"balderdash.things_baldered",
+		Tags{"pid": fmt.Sprint(1234), "host": "example.local"},
+		nil,
+	)
+
+	if _, err := WriteMeasurement(&rb, m); err != ErrNoFields {
+		t.Errorf("WriteMeasurements(m) error:\nGot %#v\nExpected %#v", err, ErrNoFields)
+	}
+
+	if rb.Len() != 0 {
+		t.Errorf("rb.Len: got=%d expected=%d", rb.Len(), 0)
+	}
+}
+
 func TestWriteMeasurement(t *testing.T) {
 	const required = `balderdash.things_baldered,host=example.local,pid=1234 on=T,value=123i 1136214245000000000` + "\n"
 

--- a/measurement_test.go
+++ b/measurement_test.go
@@ -10,6 +10,8 @@ import (
 func TestCompiledPoint(t *testing.T) {
 	const required = `service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000` + "\n"
 
+	defer prepareLogger(t)()
+
 	integer := new(Int)
 	boolean := new(Bool)
 	float := new(Float)
@@ -55,6 +57,8 @@ func TestCompiledPoint(t *testing.T) {
 func BenchmarkWriteMeasurement(b *testing.B) {
 	const result = `service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000` + "\n"
 
+	defer prepareLogger(b)()
+
 	integer := new(Int)
 	boolean := new(Bool)
 	float := new(Float)
@@ -79,6 +83,8 @@ func BenchmarkWriteMeasurement(b *testing.B) {
 func BenchmarkWriteMeasurement_Compiled(b *testing.B) {
 	const result = `service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000` + "\n"
 
+	defer prepareLogger(b)()
+
 	integer := new(Int)
 	boolean := new(Bool)
 	float := new(Float)
@@ -102,6 +108,8 @@ func BenchmarkWriteMeasurement_Compiled(b *testing.B) {
 
 func BenchmarkWriteMeasurement_Parallel(b *testing.B) {
 	const result = `service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000` + "\n"
+
+	defer prepareLogger(b)()
 
 	integer := new(Int)
 	boolean := new(Bool)
@@ -128,6 +136,8 @@ func BenchmarkWriteMeasurement_Parallel(b *testing.B) {
 
 func BenchmarkWriteMeasurement_ParallelCompiled(b *testing.B) {
 	const result = `service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000` + "\n"
+
+	defer prepareLogger(b)()
 
 	integer := new(Int)
 	boolean := new(Bool)

--- a/measurement_test.go
+++ b/measurement_test.go
@@ -54,6 +54,49 @@ func TestWriteMeasurement(t *testing.T) {
 	}
 }
 
+func TestWriteMeasurements(t *testing.T) {
+	const required = `balderdash.things_baldered,host=example.local,pid=1234 on=T,value=123i 1136214245000000000` + "\n" +
+		`system.cache_flustered,host=example.local,pid=5678 source=456i 1136214245000000000` + "\n"
+
+	defer prepareLogger(t)()
+
+	integer := new(Int)
+	otherInt := new(Int)
+	boolean := new(Bool)
+
+	boolean.Set(true)
+	integer.Set(123)
+	otherInt.Set(456)
+
+	var rb bytes.Buffer
+	ms := []Measurement{
+		NewPoint(
+			"balderdash.things_baldered",
+			Tags{"pid": fmt.Sprint(1234), "host": "example.local"},
+			Fields{"value": integer, "on": boolean},
+		),
+		NewPoint(
+			"system.cache_flustered",
+			Tags{"pid": fmt.Sprint(5678), "host": "example.local"},
+			nil,
+		),
+		NewPoint(
+			"system.cache_flustered",
+			Tags{"pid": fmt.Sprint(5678), "host": "example.local"},
+			Fields{"source": otherInt},
+		),
+	}
+
+	_, err := WriteMeasurements(&rb, ms...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bs := rb.String(); bs != required {
+		t.Errorf("Expected ---\n%s\n---\n\nGot ---\n%s\n---", required, bs)
+	}
+}
+
 func TestCompiledPoint(t *testing.T) {
 	const required = `service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000` + "\n"
 

--- a/measurement_test.go
+++ b/measurement_test.go
@@ -7,6 +7,34 @@ import (
 	"testing"
 )
 
+func TestWriteMeasurement(t *testing.T) {
+	const required = `balderdash.things_baldered,host=example.local,pid=1234 on=T,value=123i 1136214245000000000` + "\n"
+
+	defer prepareLogger(t)()
+
+	integer := new(Int)
+	boolean := new(Bool)
+
+	boolean.Set(true)
+	integer.Set(123)
+
+	var rb bytes.Buffer
+	m := NewPoint(
+		"balderdash.things_baldered",
+		Tags{"pid": fmt.Sprint(1234), "host": "example.local"},
+		Fields{"value": integer, "on": boolean},
+	)
+
+	_, err := WriteMeasurement(&rb, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bs := rb.String(); bs != required {
+		t.Errorf("Expected ---\n%s\n---\n\nGot ---\n%s\n---", required, bs)
+	}
+}
+
 func TestCompiledPoint(t *testing.T) {
 	const required = `service.some_event,host=example.local,pid=1234 depth=123.456,msg="a \"string\" of sorts",on=T,value=123i 1136214245000000000` + "\n"
 

--- a/point_set.go
+++ b/point_set.go
@@ -112,8 +112,8 @@ func (p *PointSet) alloc(ident string, opaque interface{}) (m taggedMetric, ok b
 	p.m.Lock()
 	defer p.m.Unlock()
 
-	if m, ok := p.metrics[ident]; ok {
-		return m, true
+	if metric, ok := p.metrics[ident]; ok {
+		return metric, true
 	}
 
 	key, tags, fields := p.allocator.AllocatePoint(ident, opaque)

--- a/point_set.go
+++ b/point_set.go
@@ -67,7 +67,7 @@ type taggedMetric struct {
 	fields Fields
 }
 
-func (t taggedMetric) Fields() Fields {
+func (t taggedMetric) GetFields() Fields {
 	return t.fields.Dup(false)
 }
 
@@ -129,7 +129,7 @@ func (p *PointSet) alloc(ident string, opaque interface{}) (m taggedMetric, ok b
 
 	m = taggedMetric{
 		Measurement: compiled,
-		fields:      pt.Fields(),
+		fields:      pt.GetFields(),
 	}
 	p.metrics[ident] = m
 
@@ -151,15 +151,15 @@ func (p *PointSet) lookup(ident string) (m taggedMetric, ok bool) {
 	return taggedMetric{}, false
 }
 
-// GetFields returns the fields for a particular identifier. If no point is found and no point can be allocated for the
-// identifier, it returns nil. The identifier may be an empty string.
-func (p *PointSet) GetFields(identifier string, opaque interface{}) Fields {
+// FieldsForID returns the fields for a particular identifier. If no point is found and no point can be allocated for
+// the identifier, it returns nil. The identifier may be an empty string.
+func (p *PointSet) FieldsForID(identifier string, opaque interface{}) Fields {
 	if m, ok := p.lookup(identifier); ok {
-		return m.Fields()
+		return m.GetFields()
 	}
 
 	if m, ok := p.alloc(identifier, opaque); ok {
-		return m.Fields()
+		return m.GetFields()
 	}
 
 	return nil
@@ -205,14 +205,14 @@ func (p *PointSet) WriteTo(w io.Writer) (int64, error) {
 
 // Key returns an empty string, as a PointSet is a collection of points and relies on its WriterTo implementation for
 // encoding its output.
-func (p *PointSet) Key() string {
+func (p *PointSet) GetKey() string {
 	return ""
 }
 
-func (p *PointSet) Fields() Fields {
+func (p *PointSet) GetFields() Fields {
 	return nil
 }
 
-func (p *PointSet) Tags() Tags {
+func (p *PointSet) GetTags() Tags {
 	return nil
 }

--- a/point_set.go
+++ b/point_set.go
@@ -1,0 +1,218 @@
+package dagr
+
+import (
+	"io"
+	"sync"
+)
+
+// PointAllocator is used to prepare a point from an identifier. Given the identifier, the PointAllocator must return
+// a key, tags, and fields for a new Point to use. The PointAllocator can signal that an identifier should not receive
+// a point by returning an empty key or no fields.
+//
+// The map of tags and fields are copied, so you may return prefabricated maps of tags or fields (though usually you'll
+// want at least one of a unique tag or field per point).
+//
+// The opaque value has no effect on the identifier, but can be used to pass specific information to affect the result
+// of the allocator (e.g., an *http.Request that might contain a path to include a tag).
+type PointAllocator interface {
+	AllocatePoint(identifier string, opaque interface{}) (key string, tags Tags, fields Fields)
+}
+
+// StaticPointAllocator is a simple PointAllocator that reuses a single key and set of tags and fields.
+//
+// If fields is
+// nil, IdentifierField must be non-empty, otherwise it will never produce a valid point.
+type StaticPointAllocator struct {
+	Key    string
+	Tags   Tags
+	Fields Fields // All fields will be duplicated to ensure that they're unique among points
+
+	// If either IdnetifierTag or IdentifierField is set, the tag/field with that name will be assigned the
+	// identifier passed to the StaticPointAllocator.
+	IdentifierTag   string
+	IdentifierField string
+}
+
+func (s StaticPointAllocator) AllocatePoint(identifier string, _ interface{}) (key string, tags Tags, fields Fields) {
+	tags = s.Tags
+	if s.IdentifierTag != "" {
+		if tags == nil {
+			tags = make(Tags, 1)
+		}
+		tags = s.Tags.Dup()
+		tags[s.IdentifierTag] = identifier
+	}
+
+	fields = s.Fields.Dup(true)
+	if s.IdentifierField != "" {
+		if fields == nil {
+			fields = make(Fields, 1)
+		}
+		identField := new(String)
+		identField.Set(identifier)
+		fields[s.IdentifierField] = identField
+	}
+
+	return s.Key, tags, fields
+}
+
+type PointAllocFunc func(identifier string, opaque interface{}) (key string, tags Tags, fields Fields)
+
+func (fn PointAllocFunc) AllocatePoint(identifier string, opaque interface{}) (key string, tags Tags, fields Fields) {
+	return fn(identifier, opaque)
+}
+
+type taggedMetric struct {
+	Measurement
+	fields Fields
+}
+
+func (t taggedMetric) Fields() Fields {
+	return t.fields.Dup(false)
+}
+
+// PointSet is a simple collection of (compiled) points that supports dynamic allocation and revocation of points. It is
+// intended for situations where you have a single point form varying across a tag or field, such as a request path or
+// some other varying data.
+type PointSet struct {
+	allocator PointAllocator
+	m         sync.RWMutex // controls metrics
+	metrics   map[string]taggedMetric
+}
+
+// NewPointSet allocates a new PointSet with the given allocator. If allocator is nil, the function panics with
+// ErrNoAllocator. You shouldn't bother recovering from this because there is no recovering from a PointSet without an
+// allocator.
+func NewPointSet(allocator PointAllocator) *PointSet {
+	if allocator == nil {
+		panic(ErrNoAllocator)
+	}
+
+	return &PointSet{
+		allocator: allocator,
+		metrics:   make(map[string]taggedMetric),
+	}
+}
+
+func (p *PointSet) delete(ident string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	delete(p.metrics, ident)
+}
+
+// alloc allocates a new point and stores it in the PointSet, returning a copy of the taggedMetric and whether the
+// allocation was successful. It will always check, first, whether the point was allocated prior to the lock being
+// acquired (i.e., if an alloc for the same identifier was waiting elsewhere) and return that if one was found.
+//
+// It is possible to significantly degrate PointSet performance by using an allocator that returns an empty key or
+// fields map for frequently used identifiers. In that case, it will always take a write lock and fail each time the
+// allocator returns nil. This isn't a bug, but it is something to consider when writing allocators.
+func (p *PointSet) alloc(ident string, opaque interface{}) (m taggedMetric, ok bool) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if m, ok := p.metrics[ident]; ok {
+		return m, true
+	}
+
+	key, tags, fields := p.allocator.AllocatePoint(ident, opaque)
+	if key == "" || len(fields) == 0 {
+		return m, false
+	}
+
+	pt := NewPoint(key, tags, fields)
+	compiled := pt.Compiled()
+	if compiled == nil {
+		return m, false
+	}
+
+	m = taggedMetric{
+		Measurement: compiled,
+		fields:      pt.Fields(),
+	}
+	p.metrics[ident] = m
+
+	return m, true
+}
+
+// lookup tries to find an existing metric for ident. If one is found, it returns the taggedMetric and true (otherwise,
+// nothing and false).
+//
+// lookup takes a read lock on the PointSet. This is the common case when getting a metric out of the PointSet.
+func (p *PointSet) lookup(ident string) (m taggedMetric, ok bool) {
+	p.m.RLock()
+	defer p.m.RUnlock()
+
+	if m, ok := p.metrics[ident]; ok {
+		return m, true
+	}
+
+	return taggedMetric{}, false
+}
+
+// GetFields returns the fields for a particular identifier. If no point is found and no point can be allocated for the
+// identifier, it returns nil. The identifier may be an empty string.
+func (p *PointSet) GetFields(identifier string, opaque interface{}) Fields {
+	if m, ok := p.lookup(identifier); ok {
+		return m.Fields()
+	}
+
+	if m, ok := p.alloc(identifier, opaque); ok {
+		return m.Fields()
+	}
+
+	return nil
+}
+
+// Clear erases all points held by the PointSet.
+func (p *PointSet) Clear() {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	// Retain current length as new capacity, since presumably we'll end up with the same -- you can obviously
+	// double-clear to completely zero out the initial capacity.
+	capacity := len(p.metrics)
+	p.metrics = make(map[string]taggedMetric, capacity)
+}
+
+func (p *PointSet) Remove(identifier string) {
+	p.delete(identifier)
+}
+
+func (p *PointSet) WriteTo(w io.Writer) (int64, error) {
+	buf := getBuffer(w)
+	defer putBuffer(buf)
+
+	p.m.RLock()
+	defer p.m.RUnlock()
+
+	for _, m := range p.metrics {
+		head := buf.Len()
+		if _, err := WriteMeasurement(buf, m.Measurement); err == ErrNoFields {
+			buf.Truncate(head)
+		} else if err != nil {
+			buf.Truncate(int(buf.head))
+			return 0, err
+		}
+	}
+
+	return buf.WriteTo(w)
+}
+
+// The following prevents the PointSet from looking like a valid point to anything but WriteMeasurement(s), since
+// WriteMeasurement(s) will see that it's a io.WriterTo and use that.
+
+// Key returns an empty string, as a PointSet is a collection of points and relies on its WriterTo implementation for
+// encoding its output.
+func (p *PointSet) Key() string {
+	return ""
+}
+
+func (p *PointSet) Fields() Fields {
+	return nil
+}
+
+func (p *PointSet) Tags() Tags {
+	return nil
+}

--- a/point_set_test.go
+++ b/point_set_test.go
@@ -26,7 +26,7 @@ func TestPointSet(t *testing.T) {
 	})
 
 	recordRequest := func(path string, elapsed time.Duration) {
-		fields := p.GetFields(path, nil)
+		fields := p.FieldsForID(path, nil)
 		t.Logf("Fields for identifier %q: %#+ v", path, fields)
 		fields["count"].(*Int).Add(1)
 		fields["time_taken"].(*Float).Add(elapsed.Seconds())
@@ -91,7 +91,7 @@ func TestPointSetAllocator(t *testing.T) {
 	p := NewPointSet(testAllocator)
 
 	recordRequest := func(path string, elapsed time.Duration) {
-		fields := p.GetFields(path, nil)
+		fields := p.FieldsForID(path, nil)
 		t.Logf("Fields for identifier %q: %#+ v", path, fields)
 		if fields == nil {
 			return

--- a/point_set_test.go
+++ b/point_set_test.go
@@ -1,0 +1,133 @@
+package dagr
+
+import (
+	"bytes"
+	"path"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPointSet(t *testing.T) {
+	var output = []string{
+		`http_request,host=example.local,path=/api/v1/kittens,pid=1234 count=2i,time_taken=1.7 1136214245000000000`,
+		`http_request,host=example.local,path=/api/v1/puppies,pid=1234 count=1i,time_taken=0.1 1136214245000000000`,
+	}
+
+	defer prepareLogger(t)()
+
+	p := NewPointSet(StaticPointAllocator{
+		Key:           "http_request",
+		Tags:          Tags{"host": "example.local", "pid": "1234"},
+		IdentifierTag: "path",
+		Fields:        Fields{"count": new(Int), "time_taken": new(Float)},
+	})
+
+	recordRequest := func(path string, elapsed time.Duration) {
+		fields := p.GetFields(path, nil)
+		t.Logf("Fields for identifier %q: %#+ v", path, fields)
+		fields["count"].(*Int).Add(1)
+		fields["time_taken"].(*Float).Add(elapsed.Seconds())
+	}
+
+	// Someone took extra long petting kittens
+	recordRequest("/api/v1/kittens", time.Second+time.Millisecond*200)
+	recordRequest("/api/v1/kittens", time.Millisecond*500)
+	// PUPPIES WERE FOUND WANTING. ಠ_ಠ
+	recordRequest("/api/v1/puppies", time.Millisecond*100)
+
+	var buf bytes.Buffer
+	if _, err := WriteMeasurement(&buf, p); err != nil {
+		t.Errorf("Error writing PointSet: %v", err)
+	}
+
+	out := buf.String()
+	if out == "" {
+		t.Fatal("Output from WriteMeasurement is empty")
+	}
+	out = out[:len(out)-1]
+	lines := strings.Split(out, "\n")
+	sort.Strings(lines)
+	if !reflect.DeepEqual(lines, output) {
+		t.Errorf("Expected ---\n%s\n------------\nGot --------\n%s\n------------",
+			strings.Join(lines, "\n"),
+			strings.Join(output, "\n"),
+		)
+	}
+
+	t.Logf("OUT=\n%s", out)
+}
+
+type testAllocator struct{}
+
+func TestPointSetAllocator(t *testing.T) {
+	var output = []string{
+		`http_request,host=example.local,path=/api/v1/kittens,pid=1234 count=2i,time_taken=1.7 1136214245000000000`,
+		`http_request,host=example.local,path=/api/v1/puppies,pid=1234 count=1i,time_taken=0.1 1136214245000000000`,
+	}
+
+	testAllocator := PointAllocFunc(func(ident string, _ interface{}) (key string, tags Tags, fields Fields) {
+		if dir, base := path.Split(ident); dir == "/api/v1/" && base == "turtles" {
+			// What? No, turtles aren't a thing.
+			return "", nil, nil
+		}
+
+		return "http_request",
+			Tags{
+				"host": "example.local",
+				"pid":  "1234",
+				"path": ident,
+			},
+			Fields{
+				"count":      new(Int),
+				"time_taken": new(Float),
+			}
+	})
+
+	defer prepareLogger(t)()
+
+	p := NewPointSet(testAllocator)
+
+	recordRequest := func(path string, elapsed time.Duration) {
+		fields := p.GetFields(path, nil)
+		t.Logf("Fields for identifier %q: %#+ v", path, fields)
+		if fields == nil {
+			return
+		}
+		fields["count"].(*Int).Add(1)
+		fields["time_taken"].(*Float).Add(elapsed.Seconds())
+	}
+
+	// Someone took extra long petting kittens
+	recordRequest("/api/v1/kittens", time.Second+time.Millisecond*200)
+	recordRequest("/api/v1/kittens", time.Millisecond*500)
+	// PUPPIES WERE FOUND WANTING. ಠ_ಠ
+	recordRequest("/api/v1/puppies", time.Millisecond*100)
+	// We don't record turtles but someone is very insistent that we ought to.
+	for i := 0; i < 5; i++ {
+		recordRequest("/api/v1/turtles", time.Hour*78839)
+	}
+
+	var buf bytes.Buffer
+	if _, err := WriteMeasurement(&buf, p); err != nil {
+		t.Errorf("Error writing PointSet: %v", err)
+	}
+
+	out := buf.String()
+	if out == "" {
+		t.Fatal("Output from WriteMeasurement is empty")
+	}
+	out = out[:len(out)-1]
+	lines := strings.Split(out, "\n")
+	sort.Strings(lines)
+	if !reflect.DeepEqual(lines, output) {
+		t.Errorf("Expected ---\n%s\n------------\nGot --------\n%s\n------------",
+			strings.Join(lines, "\n"),
+			strings.Join(output, "\n"),
+		)
+	}
+
+	t.Logf("OUT=\n%s", out)
+}

--- a/raw_point.go
+++ b/raw_point.go
@@ -1,0 +1,48 @@
+package dagr
+
+import (
+	"io"
+	"time"
+)
+
+// RawPoint is a simple Field implementation that has no read/write concurrency guarantees. It's useful as a read-only
+// point that can be written out and quickly discarded. It's a good idea to make use of the raw field types for this as
+// well to avoid the overhead of atomics.
+type RawPoint struct {
+	Key    string
+	Tags   Tags
+	Fields Fields
+	Time   time.Time
+}
+
+func (p RawPoint) GetKey() string {
+	return p.Key
+}
+
+func (p RawPoint) GetTags() Tags {
+	return p.Tags
+}
+
+func (p RawPoint) GetFields() Fields {
+	return p.Fields
+}
+
+func (p RawPoint) GetTime() time.Time {
+	if p.Time.IsZero() {
+		return clock.Now()
+	}
+	return p.Time
+}
+
+type RawString string
+
+var _ = Field(RawString(""))
+
+func (s RawString) WriteTo(w io.Writer) (int64, error) {
+	escaped := stringEscaper.Replace(string(s))
+	n, err := io.WriteString(w, `"`+escaped+`"`)
+	return int64(n), err
+}
+
+func (s RawString) Dup() Field      { return s }
+func (s RawString) Snapshot() Field { return s }

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,0 +1,70 @@
+package dagr
+
+import "time"
+
+// Snapshotter is an interface that any Field may implement that returns a more-or-less frozen instance of a field.
+type SnapshotField interface {
+	Field
+	Snapshot() Field
+}
+
+type SnapshotMeasurement interface {
+	Measurement
+	Snapshot() TimeMeasurement
+}
+
+// timePoint is a general-purpose measurement with a time attached, rather than being based off the current clock's
+// time. All members are considered immutable, though there are no safeguards in place to ensure it.
+type timePoint struct {
+	key    string
+	when   time.Time
+	tags   map[string]string
+	fields map[string]Field
+}
+
+var _ = TimeMeasurement(timePoint{})
+
+func (t timePoint) Time() time.Time           { return t.when }
+func (t timePoint) Key() string               { return t.key }
+func (t timePoint) Fields() map[string]Field  { return t.fields }
+func (t timePoint) Tags() map[string]string   { return t.tags }
+func (t timePoint) Snapshot() TimeMeasurement { return t }
+
+// Snapshot creates and returns a new measurement that implements TimeMeasurement. This Measurement is detached from its
+// original source and is intended to be fixed in time. This is roughly the same as duplicating a point and its fields.
+func Snapshot(m Measurement) TimeMeasurement {
+	switch m := m.(type) {
+	case timePoint:
+		return m
+	case SnapshotMeasurement:
+		// Allow the metric to take its own snapshot, if it supports that. This is necessary for compiled
+		// points, for example, since they don't return anything for their key, tags, or fields.
+		return m.Snapshot()
+	}
+	if m, ok := m.(timePoint); ok {
+		return m
+	}
+
+	var when time.Time
+	if m, ok := m.(TimeMeasurement); ok {
+		when = m.Time()
+	} else {
+		when = clock.Now()
+	}
+
+	key := m.Key()
+	tags := m.Tags()
+	fields := m.Fields()
+
+	for name, field := range fields {
+		switch f := field.(type) {
+		case SnapshotField:
+			field = f.Snapshot()
+		default:
+			field = f.Dup()
+		}
+		fields[name] = field
+	}
+
+	return timePoint{key, when, tags, fields}
+}

--- a/snapshot.go
+++ b/snapshot.go
@@ -26,12 +26,14 @@ var _ = TimeMeasurement(timePoint{})
 
 func (t timePoint) Time() time.Time           { return t.when }
 func (t timePoint) Key() string               { return t.key }
-func (t timePoint) Fields() map[string]Field  { return t.fields }
-func (t timePoint) Tags() map[string]string   { return t.tags }
+func (t timePoint) Fields() Fields            { return t.fields }
+func (t timePoint) Tags() Tags                { return t.tags }
 func (t timePoint) Snapshot() TimeMeasurement { return t }
 
 // Snapshot creates and returns a new measurement that implements TimeMeasurement. This Measurement is detached from its
 // original source and is intended to be fixed in time. This is roughly the same as duplicating a point and its fields.
+//
+// If either the measurement's key or fields are empty, Snapshot returns nil.
 func Snapshot(m Measurement) TimeMeasurement {
 	switch m := m.(type) {
 	case timePoint:
@@ -53,10 +55,31 @@ func Snapshot(m Measurement) TimeMeasurement {
 	}
 
 	key := m.Key()
-	tags := m.Tags()
-	fields := m.Fields()
+	if key == "" {
+		return nil
+	}
 
-	for name, field := range fields {
+	var (
+		srcTags   = m.Tags()
+		srcFields = m.Fields()
+		fields    = make(Fields, len(srcFields))
+		tags      Tags
+	)
+
+	// Nothing to snapshot
+	if len(srcFields) == 0 {
+		return nil
+	}
+
+	// Clone tags, if there are any
+	if len(srcTags) > 0 {
+		tags = make(Tags, len(srcTags))
+		for name, tag := range srcTags {
+			tags[name] = tag
+		}
+	}
+
+	for name, field := range srcFields {
 		switch f := field.(type) {
 		case SnapshotField:
 			field = f.Snapshot()

--- a/snapshot.go
+++ b/snapshot.go
@@ -24,10 +24,10 @@ type timePoint struct {
 
 var _ = TimeMeasurement(timePoint{})
 
-func (t timePoint) Time() time.Time           { return t.when }
-func (t timePoint) Key() string               { return t.key }
-func (t timePoint) Fields() Fields            { return t.fields }
-func (t timePoint) Tags() Tags                { return t.tags }
+func (t timePoint) GetTime() time.Time        { return t.when }
+func (t timePoint) GetKey() string            { return t.key }
+func (t timePoint) GetFields() Fields         { return t.fields }
+func (t timePoint) GetTags() Tags             { return t.tags }
 func (t timePoint) Snapshot() TimeMeasurement { return t }
 
 // Snapshot creates and returns a new measurement that implements TimeMeasurement. This Measurement is detached from its
@@ -49,19 +49,19 @@ func Snapshot(m Measurement) TimeMeasurement {
 
 	var when time.Time
 	if m, ok := m.(TimeMeasurement); ok {
-		when = m.Time()
+		when = m.GetTime()
 	} else {
 		when = clock.Now()
 	}
 
-	key := m.Key()
+	key := m.GetKey()
 	if key == "" {
 		return nil
 	}
 
 	var (
-		srcTags   = m.Tags()
-		srcFields = m.Fields()
+		srcTags   = m.GetTags()
+		srcFields = m.GetFields()
 		fields    = make(Fields, len(srcFields))
 		tags      Tags
 	)

--- a/time.go
+++ b/time.go
@@ -1,0 +1,16 @@
+package dagr
+
+import "time"
+
+// timeSource is primarily here as a test facility, since it's necessary to override time.Now for testing, as otherwise
+// we never receive a consistent time.
+type timeSource interface {
+	Now() time.Time
+}
+
+type defaultClock struct{}
+
+func (defaultClock) Now() time.Time { return time.Now() }
+
+// This is set to a fixed time in time_test.go
+var clock timeSource = defaultClock{}

--- a/time_test.go
+++ b/time_test.go
@@ -1,0 +1,19 @@
+//+build !realtime
+
+package dagr
+
+import "time"
+
+type testClock time.Time
+
+func (t testClock) Now() time.Time { return time.Time(t) }
+
+var (
+	// Not exactly the reference time since timezones are irrelevant with timestamps.
+	testTime      = time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC)
+	testTimeStamp = testTime.UnixNano()
+)
+
+func init() {
+	clock = testClock(testTime)
+}

--- a/write.go
+++ b/write.go
@@ -194,20 +194,20 @@ func WriteMeasurement(w io.Writer, m Measurement) (n int64, err error) {
 
 	var when time.Time
 	if m, ok := m.(TimeMeasurement); ok {
-		when = m.Time()
+		when = m.GetTime()
 	} else {
 		when = clock.Now()
 	}
 
-	tags := m.Tags()
-	fields := m.Fields()
+	tags := m.GetTags()
+	fields := m.GetFields()
 
 	if len(fields) == 0 {
 		return 0, ErrNoFields
 	}
 
 	// Write key
-	buf.WriteString(tagEscaper.Replace(m.Key()))
+	buf.WriteString(tagEscaper.Replace(m.GetKey()))
 
 	nameLen := len(tags)
 	if l := len(fields); l > nameLen {

--- a/write.go
+++ b/write.go
@@ -207,7 +207,7 @@ func WriteMeasurement(w io.Writer, m Measurement) (n int64, err error) {
 	}
 
 	// Write key
-	buf.WriteString(m.Key())
+	buf.WriteString(tagEscaper.Replace(m.Key()))
 
 	nameLen := len(tags)
 	if l := len(fields); l > nameLen {

--- a/write.go
+++ b/write.go
@@ -106,6 +106,10 @@ var tagEscaper = strings.NewReplacer(
 )
 
 func writeFields(buf *tempBuffer, fields Fields, names []string) error {
+	if len(names) == 0 {
+		return ErrNoFields
+	}
+
 	for i, name := range names {
 		field := fields[name]
 		if i > 0 {

--- a/write.go
+++ b/write.go
@@ -1,0 +1,209 @@
+package dagr
+
+import (
+	"bytes"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	minBufferCapacity = 128
+	maxBufferCapacity = 65000
+)
+
+func allocMinimumBuffer() *tempBuffer {
+	return &tempBuffer{bytes.NewBuffer(make([]byte, 0, minBufferCapacity)), true, 0}
+}
+
+type tempBuffer struct {
+	*bytes.Buffer
+	owned bool
+	head  int64
+}
+
+var _ = (io.Writer)((*tempBuffer)(nil))
+var _ = (io.WriterTo)((*tempBuffer)(nil))
+
+func (t *tempBuffer) WriteTo(w io.Writer) (int64, error) {
+	diffWriters := true
+	if b, ok := w.(*bytes.Buffer); ok {
+		diffWriters = b != t.Buffer
+	}
+
+	if diffWriters {
+		return t.Buffer.WriteTo(w)
+	}
+
+	// If we're writing to an unowned buffer, just return how much we wrote to the buffer.
+	n := int64(t.Len())
+	if n < t.head {
+		// Panic if the buffer was truncated to somewhere before head. This case is supposedly impossible for
+		// owned buffers, since their heads are always 0 and their lengths are never < 0.
+		panic("tempBuffer: head > buffer length - buffer was truncated during write")
+	}
+
+	return n - t.head, nil
+}
+
+var tempBuffers = sync.Pool{
+	New: func() interface{} { return allocMinimumBuffer() },
+}
+
+func getBuffer(w io.Writer) *tempBuffer {
+	if b, ok := w.(*bytes.Buffer); b != nil && ok {
+		return &tempBuffer{b, false, int64(b.Len())}
+	}
+
+	if b, ok := tempBuffers.Get().(*tempBuffer); ok {
+		return b
+	}
+
+	// Bizzaro case: tempBuffers.New didn't work? Something should've panicked by now.
+	return allocMinimumBuffer()
+}
+
+func putBuffer(b *tempBuffer) {
+	if !b.owned {
+		return
+	}
+
+	b.head = 0
+	b.Reset()
+
+	tempBuffers.Put(b)
+}
+
+var tagEscaper = strings.NewReplacer(
+	` `, `\ `,
+	`=`, `\=`,
+	`,`, `\,`,
+)
+
+func writeFields(buf *tempBuffer, fields Fields, names []string) error {
+	for i, name := range names {
+		field := fields[name]
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(tagEscaper.Replace(name))
+		buf.WriteByte('=')
+
+		// On the off chance that the field reports an error writing, we have to be careful with it and truncate
+		// the buffer we got back to where the write started so we can leave the buffer sort of intact.
+		if _, err := field.WriteTo(buf); err != nil {
+			// This has the potential to panic IFF the buffer is being messed with from multiple goroutines.
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeTags(buf *tempBuffer, tags Tags, names []string) {
+	for _, name := range names {
+		tag := tags[name]
+		buf.WriteByte(',') // Because tags must necessarily follow a key or tag, always include the comma
+		buf.WriteString(tagEscaper.Replace(name))
+		buf.WriteByte('=')
+		buf.WriteString(tagEscaper.Replace(tag))
+	}
+}
+
+// WriteMeasurement writes a single measurement, m, to w. It returns the number of bytes written and any error that
+// occurred when writing the measurement.
+//
+// When writing tags and fields, both are sorted by name in ascending order. So, a tag named "pid" will precede a tag
+// named "version", and a field name "depth" will precede a field named "value".
+//
+// If the measurement has no fields, it returns 0 and ErrNoFields.
+//
+// If the measurement implements io.WriterTo, this simply calls that instead of WriteMeasurement.
+func WriteMeasurement(w io.Writer, m Measurement) (n int64, err error) {
+	buf := getBuffer(w)
+	head := buf.Len()
+	defer putBuffer(buf)
+
+	if mw, ok := m.(io.WriterTo); ok {
+		n, err := mw.WriteTo(buf)
+		if err != nil {
+			return n, err
+		}
+		return buf.WriteTo(w)
+	}
+
+	var when time.Time
+	if m, ok := m.(TimeMeasurement); ok {
+		when = m.Time()
+	} else {
+		when = clock.Now()
+	}
+
+	tags := m.Tags()
+	fields := m.Fields()
+
+	if len(fields) == 0 {
+		return 0, ErrNoFields
+	}
+
+	// Write key
+	buf.WriteString(m.Key())
+
+	nameLen := len(tags)
+	if l := len(fields); l > nameLen {
+		nameLen = l
+	}
+	names := make([]string, 0, nameLen)
+
+	// Write tags
+	if len(tags) > 0 {
+		for name := range tags {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		writeTags(buf, tags, names)
+
+		// Reset names slice so we can sort field names
+		names = names[0:0]
+	}
+
+	// Write fields
+	for name := range fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	buf.WriteByte(' ')
+	if err := writeFields(buf, fields, names); err != nil {
+		buf.Truncate(head)
+		return 0, err
+	}
+
+	buf.WriteByte(' ')
+	writeTimestamp(buf, when)
+	buf.WriteByte('\n')
+
+	return buf.WriteTo(w)
+}
+
+func writeTimestamp(w io.Writer, ts time.Time) (n int64, err error) {
+	var buf [20]byte
+	tsb := strconv.AppendInt(buf[0:0], ts.UnixNano(), 10)
+	in, err := w.Write(tsb)
+	return int64(in), err
+}
+
+func writeByte(w io.Writer, b byte) error {
+	if bw, ok := w.(io.ByteWriter); ok {
+		return bw.WriteByte(b)
+	}
+
+	buf := [1]byte{b}
+	n, err := w.Write(buf[0:1])
+	if err == nil && n == 0 {
+		err = io.ErrShortWrite
+	}
+	return err
+}

--- a/write.go
+++ b/write.go
@@ -124,7 +124,6 @@ func writeTags(buf *tempBuffer, tags Tags, names []string) {
 // If the measurement implements io.WriterTo, this simply calls that instead of WriteMeasurement.
 func WriteMeasurement(w io.Writer, m Measurement) (n int64, err error) {
 	buf := getBuffer(w)
-	head := buf.Len()
 	defer putBuffer(buf)
 
 	if mw, ok := m.(io.WriterTo); ok {
@@ -177,7 +176,7 @@ func WriteMeasurement(w io.Writer, m Measurement) (n int64, err error) {
 	sort.Strings(names)
 	buf.WriteByte(' ')
 	if err := writeFields(buf, fields, names); err != nil {
-		buf.Truncate(head)
+		buf.Truncate(int(buf.head))
 		return 0, err
 	}
 


### PR DESCRIPTION
**_Work in Progress**_

Formally defining this as v0 development until it stabilizes.

Defines a new implementation of dagr for use as an InfluxDB sort of client (and optionally JSON provider).

Essentially, there are two main types:
- Field — a value held by a measurement.
- Measurement — per InfluxDB 0.9.x, this is a combination of a key, zero or more tags, and one or more fields.

Measurements give fields their names and can be written to a stream (via `WriteMeasurement`, though there are caveats to that). This is somewhat counter to dagr's previous implementation ideas, most of which weren't pushed or developed very far, including it being an HTTP handler that served both an API for metrics and a frontend that consumed that API (and allowed programs to display their metrics there). Might still happen, but probably as a consumer of the dagr package and separately.

Outstanding issues:
- Missing collector similar to the 0.1.x branch
- Determine whether the collector ought to be responsible for sending data to InfluxDB instead of hoarding measurement snapshots
- Determine if a basic HTTP(S) InfluxDB client should be added to the package (likely as a separate package under dagr)
- ~~UDP client? UDP probably isn't necessary since that's just a net.Conn and writing points to it, but see the next point~~ Decided that any UDP client will be a later project.
- ~~Missing ability to write multiple measurements (buffered?)~~
- Better implementation of compiled points? Should compiled points be removed?
- Documentation is inadequate
